### PR TITLE
DOC: drop `astral` badge(s) and url(s) from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DeepChainMap
 [![PyPI](https://img.shields.io/pypi/v/deep-chainmap?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/deep-chainmap/)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/neutrinoceros/deep_chainmap/main.svg)](https://results.pre-commit.ci/latest/github/neutrinoceros/deep_chainmap/main)
-[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 
 A recursive subclass of [`collections.ChainMap`](https://docs.python.org/3/library/collections.html#collections.ChainMap).
 


### PR DESCRIPTION
Following [the announcement](https://astral.sh/blog/openai) that astral was going to be aquired by OpenAI, I don't want to advertise their tools any longer.
I'm also considering migrating to `pixi` if/when uv stops being trustworthy.